### PR TITLE
Repo is updated to add scripts to facilitate development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM php:7.2-apache
 
 # install git (needed by composer later)
-RUN apt-get update && apt-get install -y git
+# install vim (for convenience)
+RUN apt-get update && apt-get install -y git && \
+  apt-get install -y vim
 
 # copy composer from the composer Docker image
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/dev-configure.sh
+++ b/dev-configure.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ex
+
+# rewrite 000-default.conf to make /var/www/app/ the DocumentRoot
+sed -i 's/DocumentRoot \/var\/www\/html/DocumentRoot \/var\/www\/app/' \
+  /etc/apache2/sites-available/000-default.conf 
+
+# start apache
+apache2-foreground

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -ex
+
+# wrap the command in summon and pass --env-file to load secrets in env
+# docker run ... twitter-search runs a container from the twitter-search image
+# -d run in detached mode (returns the container id, or CID)
+# -p 4000:80 maps the host port 4000 to the container port 80 
+# --volume mounts the cwd as a volume in the container in /var/www/app/
+# --workdir sets the work dir in the container to /var/www/app/
+# --entrypoint ./dev-configure.sh overrides the entrypoint with our
+#   configure script, which configures the container to use
+#   our workdir as the DocumentRoot instead of the default /var/www/html/
+
+CID=$(summon docker run -d -p 4000:80 --env-file @SUMMONENVFILE \
+  --volume $PWD:/var/www/app \
+  --workdir /var/www/app/ --entrypoint ./dev-configure.sh \
+  twitter-search)
+
+# this command allows you to bash into the container so you can run commands
+# -it runs the container so you can interact it in a terminal
+
+docker exec -it $CID bash


### PR DESCRIPTION
This PR updates the repo to add a `dev.sh` script that can be run to mount the repo directory into `/var/www/app/` and reconfigure the container to use that dir as the `DocumentRoot`. The script automatically gives you a bash prompt in the container.

These changes allow you to update the app either on your local machine or in the container directly and see these changes immediately reflected in the browser.